### PR TITLE
Make it obvious what declaration_type on schedule does

### DIFF
--- a/data-modelling.md
+++ b/data-modelling.md
@@ -178,7 +178,7 @@ erDiagram
         date declaration_starts_on
         date schedule_applies_from
         date schedule_applies_to
-        declaration_type declaration_type "ENUM: started, retained-{1-3}, completed"
+        declaration_type[] allowed_declaration_types "ENUM[]: started, retained-{1-3}, completed"
     }
 ```
 


### PR DESCRIPTION
When it's just called `declaration_type` it's not clear, it represents the list of declaration types that can be declared against an application. I think `allowed_declaration_types` makes this more obvious.
